### PR TITLE
参数映射缺失

### DIFF
--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -943,6 +943,11 @@ void explodeTrojan(std::string trojan, Proxy &node) {
         network = "ws";
     }
 
+    else if (getUrlArg(addition, "type") == "grpc") {  
+        path = getUrlArg(addition, "serviceName");  
+        network = "grpc";  
+    }
+    
     if (remark.empty())
         remark = server + ":" + port;
     if (group.empty())


### PR DESCRIPTION
explodeTrojan 函数没有处理 type=grpc 和 serviceName 参数的组合。 需要在解析函数中添加对这种格式的支持，将 serviceName=db 提取并存储到 node.Path 字段中，这样在生成 Clash 配置时就能正确映射到 grpc-service-name。