### PR TITLE
Update s修复ss格式转singbox格式报错initialize outbound[x]: plugin not found ubexport.cpp

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -2597,6 +2597,7 @@ proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json,
                 proxy.AddMember("method", rapidjson::StringRef(x.EncryptMethod.c_str()), allocator);
                 proxy.AddMember("password", rapidjson::StringRef(x.Password.c_str()), allocator);
                 if (!x.Plugin.empty() && !x.PluginOption.empty()) {
+                    std::string plugin = x.Plugin;
                     if (plugin == "simple-obfs" || plugin == "obfs")
                         x.Plugin = "obfs-local";
                     if (x.Plugin != "obfs-local" && x.Plugin != "v2ray-plugin") {


### PR DESCRIPTION
ss协议插件写入singbox会乱码，导致singbox报错

例如:plugin: obfs转换singbox后会变成plugin":"'\u0000\u0000\u0000\u0000\u0000\u0000\u0000al"