### PR TITLE
explodeClash 函数在解析阶段ss格式拼接mux参数错误，导致转换其他格式时会重复添加,报错initialize outbound[1]: parse plugin_opts: empty key in ""

### DIFF
--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -400,7 +400,7 @@ void explodeVmessConf(std::string content, std::vector<Proxy> &nodes) {
     std::string streamset = "streamSettings", tcpset = "tcpSettings", wsset = "wsSettings";
     regGetMatch(content, "((?i)streamsettings)", 2, 0, &streamset);
     regGetMatch(content, "((?i)tcpsettings)", 2, 0, &tcpset);
-    regGetMatch(content, "((?1)wssettings)", 2, 0, &wsset);
+    regGetMatch(content, "((?i)wssettings)", 2, 0, &wsset);
 
     json.Parse(content.data());
     if (json.HasParseError() || !json.IsObject())

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -1290,7 +1290,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes) {
                                 singleproxy["plugin-opts"]["host"] >>= pluginopts_host;
                                 tls = safe_as<bool>(singleproxy["plugin-opts"]["tls"]) ? "tls;" : "";
                                 singleproxy["plugin-opts"]["path"] >>= path;
-                                pluginopts_mux = safe_as<bool>(singleproxy["plugin-opts"]["mux"]) ? "mux=4;" : "";
+                                pluginopts_mux = safe_as<bool>(singleproxy["plugin-opts"]["mux"]) ? "4" : "";
                             }
                             break;
                         default:
@@ -1310,7 +1310,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes) {
                         pluginopts += pluginopts_host.empty() ? "" : ";obfs-host=" + pluginopts_host;
                         break;
                     case "v2ray-plugin"_hash:
-                        pluginopts = "mode=" + pluginopts_mode + ";" + tls + pluginopts_mux;
+                        pluginopts = "mode=" + pluginopts_mode + ";" + tls;
                         if (!pluginopts_host.empty())
                             pluginopts += "host=" + pluginopts_host + ";";
                         if (!path.empty())


### PR DESCRIPTION
错误实例:{"type":"shadowsocks","tag":"🇺🇸 US-20","server":"xxx.xxx.xx.x","server_port":443,"method":"none","password":"3e96ef7d-8637-42c2-ac73-75182196e755","plugin":"v2ray-plugin","plugin_opts":"mode=websocket;tls;mux=4;host=mfvpn.fuchen.indevs.in;path=3e96ef7d-8637-42c2-ac73-75182196e755/?ed=1234;mux=mux=4;;"}