### PR TITLE
feat: support plaintext subscription sources + add local-build Docker…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Build artifacts
+build/
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+*.a
+*.o
+subconverter
+
+# Git
+.git/
+
+# IDE / editors
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Scripts Dockerfile (we use root Dockerfile)
+scripts/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+FROM alpine:3.16 AS builder
+LABEL maintainer="subconverter"
+ARG THREADS="4"
+
+# Install build tools and dependencies
+RUN apk add --no-cache --virtual .build-tools \
+        git g++ build-base linux-headers cmake python3 && \
+    apk add --no-cache --virtual .build-deps \
+        curl-dev rapidjson-dev pcre2-dev yaml-cpp-dev
+
+# Build QuickJS
+RUN git clone --no-checkout https://github.com/ftk/quickjspp.git && \
+    cd quickjspp && \
+    git fetch origin 0c00c48895919fc02da3f191a2da06addeb07f09 && \
+    git checkout 0c00c48895919fc02da3f191a2da06addeb07f09 && \
+    git submodule update --init && \
+    cmake -DCMAKE_BUILD_TYPE=Release . && \
+    make quickjs -j $THREADS && \
+    install -d /usr/lib/quickjs/ && \
+    install -m644 quickjs/libquickjs.a /usr/lib/quickjs/ && \
+    install -d /usr/include/quickjs/ && \
+    install -m644 quickjs/quickjs.h quickjs/quickjs-libc.h /usr/include/quickjs/ && \
+    install -m644 quickjspp.hpp /usr/include
+
+# Build LibCron
+RUN git clone https://github.com/PerMalmberg/libcron --depth=1 && \
+    cd libcron && \
+    git submodule update --init && \
+    cmake -DCMAKE_BUILD_TYPE=Release . && \
+    make libcron -j $THREADS && \
+    install -m644 libcron/out/Release/liblibcron.a /usr/lib/ && \
+    install -d /usr/include/libcron/ && \
+    install -m644 libcron/include/libcron/* /usr/include/libcron/ && \
+    install -d /usr/include/date/ && \
+    install -m644 libcron/externals/date/include/date/* /usr/include/date/
+
+# Build toml11
+RUN git clone https://github.com/ToruNiina/toml11 --branch="v4.3.0" --depth=1 && \
+    cd toml11 && \
+    cmake -DCMAKE_CXX_STANDARD=11 . && \
+    make install -j $THREADS
+
+# Copy local source and build
+WORKDIR /subconverter_src
+COPY . .
+RUN cmake -DCMAKE_BUILD_TYPE=Release . && \
+    make -j $THREADS
+
+# --- Final image ---
+FROM alpine:3.16
+LABEL maintainer="subconverter"
+
+RUN apk add --no-cache pcre2 libcurl yaml-cpp
+
+COPY --from=builder /subconverter_src/subconverter /usr/bin/
+COPY --from=builder /subconverter_src/base /base/
+
+ENV TZ=UTC
+RUN ln -sf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone
+
+WORKDIR /base
+EXPOSE 25500/tcp
+CMD ["subconverter"]

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -3343,7 +3343,13 @@ void explodeSub(std::string sub, std::vector<Proxy> &nodes) {
 
     //try to parse as normal subscription
     if (!processed) {
-        sub = urlSafeBase64Decode(sub);
+        // Check if content is already plaintext by detecting known proxy scheme prefixes.
+        // If the subscription contains proxy links directly (e.g. vmess://, ss://, trojan://),
+        // skip base64 decoding to avoid corrupting the content.
+        bool isPlaintext = regFind(sub, R"((vmess|vless|ss|ssr|trojan|hysteria2?|tuic|socks5?|https?|anytls|naive\+https?|mieru):\/\/)");
+        if (!isPlaintext) {
+            sub = urlSafeBase64Decode(sub);
+        }
         if (regFind(sub, "(vmess|shadowsocks|http|trojan)\\s*?=")) {
             if (explodeSurge(sub, nodes))
                 return;


### PR DESCRIPTION
…file

- subparser.cpp: detect plaintext subscriptions before attempting base64 decode. If the subscription content contains known proxy scheme prefixes (vmess://, ss://, trojan://, vless://, hysteria://, etc.) it is used as-is without base64 decoding, preventing corruption of plain-text .txt files served by providers that do not encode their subscriptions.

- Dockerfile: new multi-stage build that compiles directly from local source (replaces scripts/Dockerfile which cloned from GitHub). Builds QuickJS, LibCron, and toml11 from upstream, then compiles the local subconverter tree. Final Alpine 3.16 image exposes port 25500.

- .dockerignore: excludes build artifacts, .git, and IDE files from the Docker build context.

https://claude.ai/code/session_01GDhvQnw4FsQ5eCStAC9CR4