### PR TITLE
[fix] Format `short-id` for yaml node list

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -805,7 +805,7 @@ proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupCo
 }
 
 
-void formatterShortId(std::string &input) {
+std::string formatterShortId(std::string input) {
     std::string target = "short-id:";
     size_t startPos = input.find(target);
 
@@ -830,6 +830,7 @@ void formatterShortId(std::string &input) {
         // 继续查找下一个实例
         startPos = input.find(target, startPos + 1);
     }
+    return input;
 }
 
 std::string proxyToClash(std::vector<Proxy> &nodes, const std::string &base_conf,
@@ -879,8 +880,7 @@ std::string proxyToClash(std::vector<Proxy> &nodes, const std::string &base_conf
     //rulesetToClash(yamlnode, ruleset_content_array, ext.overwrite_original_rules, ext.clash_new_field_name);
     //std::string output_content = YAML::Dump(yamlnode);
     replaceAll(output_content, "!<str> ", "");
-    formatterShortId(output_content);
-    return output_content;
+    return formatterShortId(std::move(output_content));
 }
 
 void replaceAll(std::string &input, const std::string &search, const std::string &replace) {

--- a/src/generator/config/subexport.h
+++ b/src/generator/config/subexport.h
@@ -74,4 +74,5 @@ void proxyToQuan(std::vector<Proxy> &nodes, INIReader &ini, std::vector<RulesetC
 std::string proxyToSSD(std::vector<Proxy> &nodes, std::string &group, std::string &userinfo, extra_settings &ext);
 std::string proxyToSingBox(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, extra_settings &ext);
 void replaceAll(std::string& input, const std::string& search, const std::string& replace);
+std::string formatterShortId(std::string input);
 #endif // SUBEXPORT_H_INCLUDED

--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -703,7 +703,7 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS) {
             if (ext.nodelist) {
                 YAML::Node yamlnode;
                 proxyToClash(nodes, yamlnode, dummy_group, argTarget == "clashr", ext);
-                output_content = YAML::Dump(yamlnode);
+                output_content = formatterShortId(YAML::Dump(yamlnode));
             } else {
                 if (render_template(fetchFile(lClashBase, proxy, global.cacheConfig), tpl_args, base_content,
                                     global.templatePath) != 0) {


### PR DESCRIPTION
Apply `formatterShortId` to node list, now the `short-id` should covered in quotes when using param `list=true`

related issues:
- #57 