### PR TITLE
支持 Clash proxy group 扩展字段

### DIFF
--- a/src/config/binding.h
+++ b/src/config/binding.h
@@ -243,6 +243,17 @@ namespace INIBinding
                     continue;
                 }
 
+                while(rules_upper_bound > 2 && startsWith(vArray[rules_upper_bound - 1], "!!"))
+                {
+                    std::string keyval = vArray[rules_upper_bound - 1].substr(2);
+                    auto eqpos = keyval.find('=');
+                    if(eqpos != std::string::npos)
+                        conf.Extras[keyval.substr(0, eqpos)] = keyval.substr(eqpos + 1);
+                    else
+                        conf.Extras[keyval] = "true";
+                    rules_upper_bound--;
+                }
+
                 if(conf.Type == ProxyGroupType::URLTest || conf.Type == ProxyGroupType::LoadBalance || conf.Type == ProxyGroupType::Fallback)
                 {
                     if(rules_upper_bound < 5)

--- a/src/config/binding.h
+++ b/src/config/binding.h
@@ -84,6 +84,12 @@ namespace toml
                 throw serialization_error(format_error("Proxy Group must contains at least one of proxy match rule or provider!", v.location(), "here"), v.location());
             if(v.contains("disable-udp"))
                 conf.DisableUdp = find_or(v, "disable-udp", conf.DisableUdp.get());
+            if(v.contains("extra"))
+            {
+                const auto& extra_table = toml::find<toml::table>(v, "extra");
+                for(const auto& [k, val] : extra_table)
+                    conf.Extras[k] = toml::format(val);
+            }
             return conf;
         }
     };
@@ -253,6 +259,15 @@ namespace INIBinding
                         string_array list = split(vArray[i].substr(11), ",");
                         conf.UsingProvider.reserve(conf.UsingProvider.size() + list.size());
                         std::move(list.begin(), list.end(), std::back_inserter(conf.UsingProvider));
+                    }
+                    else if(startsWith(vArray[i], "!!"))
+                    {
+                        std::string keyval = vArray[i].substr(2);
+                        auto eqpos = keyval.find('=');
+                        if(eqpos != std::string::npos)
+                            conf.Extras[keyval.substr(0, eqpos)] = keyval.substr(eqpos + 1);
+                        else
+                            conf.Extras[keyval] = "true";
                     }
                     else
                         conf.Proxies.emplace_back(std::move(vArray[i]));

--- a/src/config/proxygroup.h
+++ b/src/config/proxygroup.h
@@ -35,6 +35,7 @@ struct ProxyGroupConfig
     Boolean DisableUdp;
     Boolean Persistent;
     Boolean EvaluateBeforeUse;
+    string_map Extras;
 
     String TypeStr() const
     {

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -808,6 +808,8 @@ proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupCo
         }
         if (!x.DisableUdp.is_undef())
             singlegroup["disable-udp"] = x.DisableUdp.get();
+        for (const auto &[key, value] : x.Extras)
+            singlegroup[key] = yamlScalarFromString(value);
 
         for (const auto &y: x.Proxies)
             groupGenerate(y, nodelist, filtered_nodelist, true, ext);

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -3421,8 +3421,26 @@ void explodeSub(std::string sub, std::vector<Proxy> &nodes) {
     }
 
     try {
-        if (!processed && regFind(sub, "\"?(Proxy|proxies)\"?:")) {
+        const std::string trimmed_sub = trimWhitespace(sub, true, false);
+        const bool may_be_clash = regFind(sub, "\"?(Proxy|proxies)\"?:") ||
+                                  startsWith(trimmed_sub, "-") || startsWith(trimmed_sub, "[");
+        if (!processed && may_be_clash) {
             Node yamlnode = Load(sub);
+            if (yamlnode.IsSequence() && yamlnode.size()) {
+                bool is_proxy_sequence = true;
+                for (std::size_t i = 0; i < yamlnode.size(); ++i) {
+                    const Node item = yamlnode[i];
+                    if (!item.IsMap() || !item["type"].IsScalar()) {
+                        is_proxy_sequence = false;
+                        break;
+                    }
+                }
+                if (is_proxy_sequence) {
+                    Node normalized;
+                    normalized["proxies"] = yamlnode;
+                    yamlnode = normalized;
+                }
+            }
             if (yamlnode.IsDefined() && yamlnode.IsMap()) {
                 const std::string section = yamlnode["proxies"].IsDefined() ? "proxies" : "Proxy";
                 if (yamlnode[section].IsDefined() && yamlnode[section].IsSequence()) {

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -60,6 +60,49 @@ const string_array xhttp_option_keys = {
     "sc-stream-up-server-secs"
 };
 
+static std::string readClashTuicAlpn(const Node &singleproxy, const std::string &proxy_name) {
+    const Node alpn_node = singleproxy["alpn"];
+    if (!alpn_node.IsDefined() || alpn_node.IsNull())
+        return "";
+
+    const auto warn = [&proxy_name](const std::string &reason) {
+        const std::string name = proxy_name.empty() ? "" : " for proxy '" + proxy_name + "'";
+        writeLog(0, "Ignoring invalid Clash TUIC alpn" + name + ": " + reason, LOG_LEVEL_WARNING);
+    };
+    const auto read_scalar = [&warn](const Node &value) {
+        try {
+            return trim(value.as<std::string>());
+        } catch (const YAML::Exception &e) {
+            warn(e.what());
+            return std::string();
+        }
+    };
+
+    if (alpn_node.IsScalar())
+        return read_scalar(alpn_node);
+
+    if (alpn_node.IsSequence()) {
+        string_array values;
+        for (std::size_t i = 0; i < alpn_node.size(); ++i) {
+            const Node value = alpn_node[i];
+            if (!value.IsDefined() || value.IsNull())
+                continue;
+            if (!value.IsScalar()) {
+                warn("sequence item " + std::to_string(i) + " is not a scalar");
+                continue;
+            }
+
+            std::string item = read_scalar(value);
+            if (!item.empty())
+                values.emplace_back(std::move(item));
+        }
+        return join(values, ",");
+    }
+
+    warn("expected a scalar or sequence");
+    return "";
+}
+
 //remake from speedtestutil
 std::string removeBrackets(const std::string& input) {
     std::string result = input;
@@ -1622,9 +1665,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes) {
                 singleproxy["congestion-controller"] >>= congestion_control;
                 singleproxy["udp-relay-mode"] >>= udp_relay_mode;
                 singleproxy["sni"] >>= sni;
-                if (!singleproxy["alpn"].IsNull()) {
-                    singleproxy["alpn"][0] >>= alpn;
-                }
+                alpn = readClashTuicAlpn(singleproxy, ps);
                 singleproxy["disable-sni"] >>= disableSni;
                 singleproxy["reduce-rtt"] >>= reduceRtt;
                 singleproxy["token"] >>= token;

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -3438,7 +3438,7 @@ void explodeSub(std::string sub, std::vector<Proxy> &nodes) {
                 if (is_proxy_sequence) {
                     Node normalized;
                     normalized["proxies"] = yamlnode;
-                    yamlnode = normalized;
+                    yamlnode.reset(normalized);
                 }
             }
             if (yamlnode.IsDefined() && yamlnode.IsMap()) {

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -60,49 +60,6 @@ const string_array xhttp_option_keys = {
     "sc-stream-up-server-secs"
 };
 
-static std::string readClashTuicAlpn(const Node &singleproxy, const std::string &proxy_name) {
-    const Node alpn_node = singleproxy["alpn"];
-    if (!alpn_node.IsDefined() || alpn_node.IsNull())
-        return "";
-
-    const auto warn = [&proxy_name](const std::string &reason) {
-        const std::string name = proxy_name.empty() ? "" : " for proxy '" + proxy_name + "'";
-        writeLog(0, "Ignoring invalid Clash TUIC alpn" + name + ": " + reason, LOG_LEVEL_WARNING);
-    };
-    const auto read_scalar = [&warn](const Node &value) {
-        try {
-            return trim(value.as<std::string>());
-        } catch (const YAML::Exception &e) {
-            warn(e.what());
-            return std::string();
-        }
-    };
-
-    if (alpn_node.IsScalar())
-        return read_scalar(alpn_node);
-
-    if (alpn_node.IsSequence()) {
-        string_array values;
-        for (std::size_t i = 0; i < alpn_node.size(); ++i) {
-            const Node value = alpn_node[i];
-            if (!value.IsDefined() || value.IsNull())
-                continue;
-            if (!value.IsScalar()) {
-                warn("sequence item " + std::to_string(i) + " is not a scalar");
-                continue;
-            }
-
-            std::string item = read_scalar(value);
-            if (!item.empty())
-                values.emplace_back(std::move(item));
-        }
-        return join(values, ",");
-    }
-
-    warn("expected a scalar or sequence");
-    return "";
-}
-
 //remake from speedtestutil
 std::string removeBrackets(const std::string& input) {
     std::string result = input;
@@ -1665,7 +1622,9 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes) {
                 singleproxy["congestion-controller"] >>= congestion_control;
                 singleproxy["udp-relay-mode"] >>= udp_relay_mode;
                 singleproxy["sni"] >>= sni;
-                alpn = readClashTuicAlpn(singleproxy, ps);
+                if (!singleproxy["alpn"].IsNull()) {
+                    singleproxy["alpn"][0] >>= alpn;
+                }
                 singleproxy["disable-sni"] >>= disableSni;
                 singleproxy["reduce-rtt"] >>= reduceRtt;
                 singleproxy["token"] >>= token;
@@ -3420,39 +3379,20 @@ void explodeSub(std::string sub, std::vector<Proxy> &nodes) {
         processed = true;
     }
 
+    //try to parse as clash configuration
     try {
-        const std::string trimmed_sub = trimWhitespace(sub, true, false);
-        const bool may_be_clash = regFind(sub, "\"?(Proxy|proxies)\"?:") ||
-                                  startsWith(trimmed_sub, "-") || startsWith(trimmed_sub, "[");
-        if (!processed && may_be_clash) {
+        if (!processed && regFind(sub, "\"?(Proxy|proxies)\"?:")) {
+            regGetMatch(sub, R"(^(?:Proxy|proxies):$\s(?:(?:^ +?.*$| *?-.*$|)\s?)+)", 1, &sub);
             Node yamlnode = Load(sub);
-            if (yamlnode.IsSequence() && yamlnode.size()) {
-                bool is_proxy_sequence = true;
-                for (std::size_t i = 0; i < yamlnode.size(); ++i) {
-                    const Node item = yamlnode[i];
-                    if (!item.IsMap() || !item["type"].IsScalar()) {
-                        is_proxy_sequence = false;
-                        break;
-                    }
-                }
-                if (is_proxy_sequence) {
-                    Node normalized;
-                    normalized["proxies"] = yamlnode;
-                    yamlnode.reset(normalized);
-                }
-            }
-            if (yamlnode.IsDefined() && yamlnode.IsMap()) {
-                const std::string section = yamlnode["proxies"].IsDefined() ? "proxies" : "Proxy";
-                if (yamlnode[section].IsDefined() && yamlnode[section].IsSequence()) {
-                    const auto node_count = nodes.size();
-                    explodeClash(yamlnode, nodes);
-                    processed = nodes.size() > node_count;
-                }
+            if (yamlnode.size() && (yamlnode["Proxy"].IsDefined() || yamlnode["proxies"].IsDefined())) {
+                explodeClash(yamlnode, nodes);
+                processed = true;
             }
         }
     } catch (std::exception &e) {
         //writeLog(0, e.what(), LOG_LEVEL_DEBUG);
         //ignore
+        throw;
     }
     try {
         std::string pattern = "\"?(inbounds)\"?:";

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -3379,20 +3379,21 @@ void explodeSub(std::string sub, std::vector<Proxy> &nodes) {
         processed = true;
     }
 
-    //try to parse as clash configuration
     try {
         if (!processed && regFind(sub, "\"?(Proxy|proxies)\"?:")) {
-            regGetMatch(sub, R"(^(?:Proxy|proxies):$\s(?:(?:^ +?.*$| *?-.*$|)\s?)+)", 1, &sub);
             Node yamlnode = Load(sub);
-            if (yamlnode.size() && (yamlnode["Proxy"].IsDefined() || yamlnode["proxies"].IsDefined())) {
-                explodeClash(yamlnode, nodes);
-                processed = true;
+            if (yamlnode.IsDefined() && yamlnode.IsMap()) {
+                const std::string section = yamlnode["proxies"].IsDefined() ? "proxies" : "Proxy";
+                if (yamlnode[section].IsDefined() && yamlnode[section].IsSequence()) {
+                    const auto node_count = nodes.size();
+                    explodeClash(yamlnode, nodes);
+                    processed = nodes.size() > node_count;
+                }
             }
         }
     } catch (std::exception &e) {
         //writeLog(0, e.what(), LOG_LEVEL_DEBUG);
         //ignore
-        throw;
     }
     try {
         std::string pattern = "\"?(inbounds)\"?:";


### PR DESCRIPTION
 mihomo持续为 proxy group 添加新字段（如 empty-fallback、interrupt 等），subconverter当前仅支持转换固定的字段集合，无法覆盖这些新增的 meta 特性。为 custom_proxy_group 引入通用扩展字段机制：用户可通过 !!key=value 语法（如 !!empty-fallback=DIRECT）在配置中指定任意Clash proxy group 字段，转换时自动写入 YAML 输出，仅对 Clash 格式生效，向后兼容现有配置，无需逐个适配 mihomo新增字段。