### PR TITLE
Allow Snell v4 and v5 in Clash output

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -487,8 +487,6 @@ proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupCo
                 }
                 break;
             case ProxyType::Snell:
-                if (x.SnellVersion >= 4)
-                    continue;
                 singleproxy["type"] = "snell";
                 singleproxy["psk"] = x.Password;
                 if (x.SnellVersion != 0)
@@ -742,9 +740,8 @@ proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupCo
                 continue;
         }
 
-        // UDP is not supported yet in clash using snell
-        // sees in https://dreamacro.github.io/clash/configuration/outbound.html#snell
-        if (udp && x.Type != ProxyType::Snell && x.Type != ProxyType::TUIC)
+        // Snell UDP is available in mihomo-compatible Snell v3+ nodes.
+        if (udp && (x.Type != ProxyType::Snell || x.SnellVersion >= 3) && x.Type != ProxyType::TUIC)
             singleproxy["udp"] = true;
         if (!clashR && !x.UnderlyingProxy.empty())
             singleproxy["dialer-proxy"] = x.UnderlyingProxy;


### PR DESCRIPTION
This keeps Snell v4/v5 nodes when exporting Clash-compatible YAML instead of dropping them.

Changes:
- Do not skip Snell nodes with version >= 4 in Clash export.
- Preserve udp: true for Snell v3+ nodes, which is supported by mihomo-compatible Snell configurations.

This is intended to make target=clash output usable with mihomo Snell v4/v5 nodes.