### PR TITLE
feat: support explicit rule-provider format in rulesets

### DIFF
--- a/src/config/binding.h
+++ b/src/config/binding.h
@@ -135,6 +135,17 @@ namespace toml
                 throw serialization_error(format_error("Ruleset has unsupported type!", v.at("type").location(), "should be one of following: surge-ruleset, quantumultx, clash-domain, clash-ipcidr, clash-classic"), v.at("type").location());
             }
             conf.Url += find<String>(v, "ruleset");
+            conf.Format = find_or<String>(v, "format", "");
+            if(!conf.Format.empty())
+            {
+                conf.Format = toLower(conf.Format);
+                if(type != "clash-domain" && type != "clash-ipcidr" && type != "clash-classic")
+                    throw serialization_error(format_error("Ruleset format is only supported for Clash rule-providers!", v.at("format").location(), "format is valid only with type: clash-domain, clash-ipcidr, clash-classic"), v.at("format").location());
+                if(conf.Format != "yaml" && conf.Format != "text" && conf.Format != "mrs")
+                    throw serialization_error(format_error("Ruleset has unsupported format!", v.at("format").location(), "should be one of following: yaml, text, mrs"), v.at("format").location());
+                if(conf.Format == "mrs" && type == "clash-classic")
+                    throw serialization_error(format_error("Ruleset format mrs is unsupported for clash-classic!", v.at("format").location(), "mrs can only be used with clash-domain or clash-ipcidr"), v.at("format").location());
+            }
             conf.Interval = find_or<Integer>(v, "interval", 86400);
             return conf;
         }

--- a/src/config/ruleset.h
+++ b/src/config/ruleset.h
@@ -17,10 +17,11 @@ struct RulesetConfig
     String Group;
     //RulesetType Type = RulesetType::SurgeRuleset;
     String Url;
+    String Format;
     Integer Interval = 86400;
     bool operator==(const RulesetConfig &r) const
     {
-        return Group == r.Group && Url == r.Url && Interval == r.Interval;
+        return Group == r.Group && Url == r.Url && Format == r.Format && Interval == r.Interval;
     }
 };
 

--- a/src/generator/config/ruleconvert.h
+++ b/src/generator/config/ruleconvert.h
@@ -24,6 +24,7 @@ struct RulesetContent
     std::string rule_group;
     std::string rule_path;
     std::string rule_path_typed;
+    std::string rule_format;
     int rule_type = RULESET_SURGE;
     std::shared_future<std::string> rule_content;
     int update_interval = 0;

--- a/src/generator/template/templates.cpp
+++ b/src/generator/template/templates.cpp
@@ -317,6 +317,7 @@ int renderClashScript(YAML::Node &base_rule, std::vector<RulesetContent> &rulese
     string_map keywords, urls, names;
     std::map<std::string, bool> has_domain, has_ipcidr;
     std::map<std::string, int> ruleset_interval, rule_type;
+    string_map ruleset_format;
     string_array rules;
     int index = 0;
 
@@ -365,6 +366,7 @@ int renderClashScript(YAML::Node &base_rule, std::vector<RulesetContent> &rulese
                 urls[rule_name] = "*" + rule_path;
                 rule_type[rule_name] = x.rule_type;
                 ruleset_interval[rule_name] = x.update_interval;
+                ruleset_format[rule_name] = x.rule_format;
                 switch(x.rule_type)
                 {
                 case RULESET_CLASH_IPCIDR:
@@ -394,6 +396,7 @@ int renderClashScript(YAML::Node &base_rule, std::vector<RulesetContent> &rulese
                     urls[rule_name] = rule_path_typed;
                     rule_type[rule_name] = x.rule_type;
                     ruleset_interval[rule_name] = x.update_interval;
+                    ruleset_format[rule_name] = x.rule_format;
                     if(clash_classical_ruleset)
                     {
                         if(!script)
@@ -485,6 +488,7 @@ int renderClashScript(YAML::Node &base_rule, std::vector<RulesetContent> &rulese
         std::string url = urls[x], keyword = keywords[x], name = names[x];
         bool group_has_domain = has_domain[x], group_has_ipcidr = has_ipcidr[x];
         int interval = ruleset_interval[x];
+        std::string format = ruleset_format[x];
 
         if(group_has_domain)
         {
@@ -498,6 +502,8 @@ int renderClashScript(YAML::Node &base_rule, std::vector<RulesetContent> &rulese
             else
                 base_rule["rule-providers"][yaml_key]["url"] = remote_path_prefix + "/getruleset?type=3&url=" + urlSafeBase64Encode(url);
             base_rule["rule-providers"][yaml_key]["path"] = "./providers/" + std::to_string(hash_(url)) + "_domain.yaml";
+            if(!format.empty())
+                base_rule["rule-providers"][yaml_key]["format"] = format;
             if(interval)
                 base_rule["rule-providers"][yaml_key]["interval"] = interval;
         }
@@ -513,6 +519,8 @@ int renderClashScript(YAML::Node &base_rule, std::vector<RulesetContent> &rulese
             else
                 base_rule["rule-providers"][yaml_key]["url"] = remote_path_prefix + "/getruleset?type=4&url=" + urlSafeBase64Encode(url);
             base_rule["rule-providers"][yaml_key]["path"] = "./providers/" + std::to_string(hash_(url)) + "_ipcidr.yaml";
+            if(!format.empty())
+                base_rule["rule-providers"][yaml_key]["format"] = format;
             if(interval)
                 base_rule["rule-providers"][yaml_key]["interval"] = interval;
         }
@@ -526,6 +534,8 @@ int renderClashScript(YAML::Node &base_rule, std::vector<RulesetContent> &rulese
             else
                 base_rule["rule-providers"][yaml_key]["url"] = remote_path_prefix + "/getruleset?type=6&url=" + urlSafeBase64Encode(url);
             base_rule["rule-providers"][yaml_key]["path"] = "./providers/" + std::to_string(hash_(url)) + ".yaml";
+            if(!format.empty())
+                base_rule["rule-providers"][yaml_key]["format"] = format;
             if(interval)
                 base_rule["rule-providers"][yaml_key]["interval"] = interval;
         }

--- a/src/handler/settings.cpp
+++ b/src/handler/settings.cpp
@@ -260,7 +260,7 @@ void refreshRulesets(RulesetConfigs &ruleset_list, std::vector<RulesetContent> &
         if(pos != std::string::npos)
         {
             writeLog(0, "Adding rule '" + rule_url.substr(pos + 2) + "," + rule_group + "'.", LOG_LEVEL_INFO);
-            rc = {rule_group, "", "", RULESET_SURGE, std::async(std::launch::async, [=](){return rule_url.substr(pos);}), 0};
+            rc = {rule_group, "", "", "", RULESET_SURGE, std::async(std::launch::async, [=](){return rule_url.substr(pos);}), 0};
         }
         else
         {
@@ -273,7 +273,7 @@ void refreshRulesets(RulesetConfigs &ruleset_list, std::vector<RulesetContent> &
                 type = iter->second;
             }
             writeLog(0, "Updating ruleset url '" + rule_url + "' with group '" + rule_group + "'.", LOG_LEVEL_INFO);
-            rc = {rule_group, rule_url, rule_url_typed, type, fetchFileAsync(rule_url, proxy, global.cacheRuleset, true, global.asyncFetchRuleset), x.Interval};
+            rc = {rule_group, rule_url, rule_url_typed, x.Format, type, fetchFileAsync(rule_url, proxy, global.cacheRuleset, true, global.asyncFetchRuleset), x.Interval};
         }
         ruleset_content_array.emplace_back(std::move(rc));
     }


### PR DESCRIPTION
Add support for an optional `format` field in external ruleset definitions so Clash/Mihomo rule-providers can declare their source format explicitly.

Previously, `type = "clash-domain"`, `type = "clash-ipcidr"`, and `type = "clash-classic"` only described the provider behavior, while the provider format was implicitly left as the Clash/Mihomo default YAML format. This worked for YAML rule-provider files with a top-level `payload` field, but failed for valid text-format providers such as domainset files that contain plain domain entries without a `payload` wrapper.

This change allows users to configure:

    [[rulesets]]
    group = "Apple CDN"
    ruleset = "https://ruleset.skk.moe/Clash/domainset/apple_cdn.txt"
    type = "clash-domain"
    format = "text"

The generated rule-provider will now include:

    format: text

Supported values are:

    yaml
    text
    mrs

The new `format` option is only accepted for Clash/Mihomo native rule-provider types:

    clash-domain
    clash-ipcidr
    clash-classic

For compatibility, omitting `format` preserves the previous behavior and does not emit a `format` field, allowing Clash/Mihomo to continue using its default YAML format.

Validation is also added to reject unsupported format values and to prevent `format = "mrs"` from being used with `clash-classic`, since MRS rule-sets only support domain and IP-CIDR behaviors.