### PR TITLE
fix(anytls): preserve client-fingerprint, idle-session and tfo in Cla…

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGISTRY_IMAGE: asdlokj1qpi23/subconverter
+  GHCR_IMAGE: ghcr.io/haoqianwei/subconverter
 
 jobs:
   build:
@@ -47,16 +47,17 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ${{ env.GHCR_IMAGE }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Docker login
+      - name: Docker login (GHCR)
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get commit SHA
         if: github.ref == 'refs/heads/master'
@@ -72,7 +73,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SHA=${{ steps.vars.outputs.sha_short }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -108,23 +109,24 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ${{ env.GHCR_IMAGE }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Docker login
+      - name: Docker login (GHCR)
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)      
+            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)      
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -37,7 +37,7 @@ RUN set -xe && \
     cmake -DCMAKE_CXX_STANDARD=11 . && \
     make install -j $THREADS && \
     cd .. && \
-    git clone https://github.com/asdlokj1qpi233/subconverter --depth=1 && \
+    git clone https://github.com/haoqianwei/subconverter --depth=1 && \
     cd subconverter && \
     [ -n "$SHA" ] && sed -i 's/\(v[0-9]\.[0-9]\.[0-9]\)/\1-'"$SHA"'/' src/version.h;\
     python3 -m ensurepip && \

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -599,10 +599,13 @@ proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupCo
                     singleproxy["password"] = x.Password;
                 }
                 if (!x.Fingerprint.empty()) {
-                    singleproxy["fingerprint"] = x.Fingerprint;
+                    singleproxy["client-fingerprint"] = x.Fingerprint;
                 }
                 if (!udp.is_undef()) {
                     singleproxy["udp"] = udp.get();
+                }
+                if (!tfo.is_undef()) {
+                    singleproxy["tfo"] = tfo.get();
                 }
                 if (!x.SNI.empty()) {
                     singleproxy["sni"] = x.SNI;
@@ -614,6 +617,12 @@ proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupCo
                         singleproxy["alpn"].push_back(item);
                     }
                 }
+                if (x.IdleSessionCheckIntervalSet)
+                    singleproxy["idle-session-check-interval"] = x.IdleSessionCheckInterval;
+                if (x.IdleSessionTimeoutSet)
+                    singleproxy["idle-session-timeout"] = x.IdleSessionTimeout;
+                if (x.MinIdleSessionSet)
+                    singleproxy["min-idle-session"] = x.MinIdleSession;
                 break;
             case ProxyType::Mieru:
                 singleproxy["type"] = "mieru";

--- a/src/parser/config/proxy.h
+++ b/src/parser/config/proxy.h
@@ -92,6 +92,9 @@ struct Proxy {
     uint16_t IdleSessionCheckInterval=30;
     uint16_t IdleSessionTimeout=30;
     uint16_t MinIdleSession=0;
+    bool IdleSessionCheckIntervalSet=false;
+    bool IdleSessionTimeoutSet=false;
+    bool MinIdleSessionSet=false;
     String TLSStr;
     bool TLSSecure = false;
 

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -1708,10 +1708,16 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes) {
                         alpns.push_back(alpn2);
                     }
                 }
-                singleproxy["fingerprint"] >>= fingerprint;
+                singleproxy["client-fingerprint"] >>= fingerprint;
                 anyTlSConstruct(node, ANYTLS_DEFAULT_GROUP, ps, port, password, server, alpns, fingerprint, sni,
                                 udp,
-                                tribool(), scv, tribool(), underlying_proxy, 30, 30, 0);
+                                tribool(), scv, tribool(), underlying_proxy,
+                                singleproxy["idle-session-check-interval"].IsDefined() ? singleproxy["idle-session-check-interval"].as<uint16_t>() : 30,
+                                singleproxy["idle-session-timeout"].IsDefined() ? singleproxy["idle-session-timeout"].as<uint16_t>() : 30,
+                                singleproxy["min-idle-session"].IsDefined() ? singleproxy["min-idle-session"].as<uint16_t>() : 0);
+                node.IdleSessionCheckIntervalSet = singleproxy["idle-session-check-interval"].IsDefined();
+                node.IdleSessionTimeoutSet = singleproxy["idle-session-timeout"].IsDefined();
+                node.MinIdleSessionSet = singleproxy["min-idle-session"].IsDefined();
                 break;
             case "mieru"_hash:
                 group = MIERU_DEFAULT_GROUP;


### PR DESCRIPTION
…sh YAML

- Parse: read 'client-fingerprint' instead of 'fingerprint' (mihomo field name)
- Parse: read idle-session-check-interval/timeout and min-idle-session from YAML
- Export: write 'client-fingerprint' instead of 'fingerprint'
- Export: add tfo output
- Export: add idle-session-* output (only when set in source)
- Add bool flags to Proxy struct to track whether idle-session fields were user-set
- CI: push image to ghcr.io instead of Docker Hub
- Dockerfile: clone from fork repo