### PR TITLE
feat: support pinSHA256 fingerprint for hysteria2

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -545,6 +545,9 @@ proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupCo
                 if (!x.PublicKey.empty()) {
                     singleproxy["ca-str"] = x.PublicKey;
                 }
+                if (!x.Fingerprint.empty()) {
+                    singleproxy["fingerprint"] = x.Fingerprint;
+                }
                 if (!x.ServerName.empty()) {
                     singleproxy["sni"] = x.ServerName;
                 }
@@ -1357,6 +1360,9 @@ std::string proxyToSingle(std::vector<Proxy> &nodes, int types, extra_settings &
                 }
                 if (!sni.empty()) {
                     proxyStr += "&sni=" + sni;
+                }
+                if (!x.Fingerprint.empty()) {
+                    proxyStr += "&pinSHA256=" + x.Fingerprint;
                 }
                 proxyStr += "#" + urlEncode(remark);
                 break;

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -405,7 +405,7 @@ void hysteria2Construct(Proxy &node, const std::string &group, const std::string
                         const std::string &port, const std::string &password, const std::string &host,
                         const std::string &up, const std::string &down, const std::string &alpn,
                         const std::string &obfsParam, const std::string &obfsPassword, const std::string &sni,
-                        const std::string &publicKey, const std::string &ports,
+                        const std::string &publicKey, const std::string &fingerprint, const std::string &ports,
                         tribool udp, tribool tfo,
                         tribool scv, const std::string &underlying_proxy) {
     commonConstruct(node, ProxyType::Hysteria2, group, remarks, add, port, udp, tfo, scv, tribool(), underlying_proxy);
@@ -418,6 +418,7 @@ void hysteria2Construct(Proxy &node, const std::string &group, const std::string
     node.OBFSPassword = obfsPassword;
     node.ServerName = sni;
     node.PublicKey = publicKey;
+    node.Fingerprint = fingerprint;
     node.Ports = ports;
 }
 
@@ -1670,9 +1671,10 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes) {
                 singleproxy["sni"] >>= host;
                 singleproxy["alpn"][0] >>= alpn;
                 singleproxy["ports"] >> ports;
+                singleproxy["fingerprint"] >>= fingerprint;
                 sni = host;
                 hysteria2Construct(node, group, ps, server, port, password, host, up, down, alpn, obfsParam,
-                                   obfsPassword, sni, public_key, ports, udp, tfo, scv, underlying_proxy);
+                                   obfsPassword, sni, public_key, fingerprint, ports, udp, tfo, scv, underlying_proxy);
                 break;
             case "tuic"_hash:
                 group = TUIC_DEFAULT_GROUP;
@@ -1851,6 +1853,7 @@ void explodeStdMieru(std::string mieru, Proxy &node) {
 
 void explodeStdHysteria2(std::string hysteria2, Proxy &node) {
     std::string add, port, password, host, insecure, up, down, alpn, obfsParam, obfsPassword, remarks, sni, ports;
+    std::string fingerprint;
     std::string addition;
     tribool scv;
     hysteria2 = hysteria2.substr(12);
@@ -1888,11 +1891,12 @@ void explodeStdHysteria2(std::string hysteria2, Proxy &node) {
     host = getUrlArg(addition, "sni");
     sni = getUrlArg(addition, "sni");
     ports = getUrlArg(addition, "ports");
+    fingerprint = getUrlArg(addition, "pinSHA256");
     if (remarks.empty())
         remarks = add + ":" + port;
 
     hysteria2Construct(node, HYSTERIA2_DEFAULT_GROUP, remarks, add, port, password, host, up, down, alpn, obfsParam,
-                       obfsPassword, host, "", ports, tribool(), tribool(), scv);
+                       obfsPassword, host, "", fingerprint, ports, tribool(), tribool(), scv);
     return;
 }
 
@@ -3098,6 +3102,13 @@ void explodeSingbox(rapidjson::Value &outbounds, std::vector<Proxy> &nodes) {
                     if (tlsObj.HasMember("certificate") && tlsObj["certificate"].IsString()) {
                         public_key = tlsObj["certificate"].GetString();
                     }
+                    if (tlsObj.HasMember("certificate_public_key_sha256") &&
+                        tlsObj["certificate_public_key_sha256"].IsArray() && !tlsObj["certificate_public_key_sha256"].Empty()) {
+                        rapidjson::Value certFpArr = tlsObj["certificate_public_key_sha256"].GetArray();
+                        if (certFpArr[0].IsString()) {
+                            fingerprint = certFpArr[0].GetString();
+                        }
+                    }
                     if (tlsObj.HasMember("reality") && tlsObj["reality"].IsObject()) {
                         tls = "reality";
                         rapidjson::Value reality = tlsObj["reality"].GetObject();
@@ -3260,7 +3271,7 @@ void explodeSingbox(rapidjson::Value &outbounds, std::vector<Proxy> &nodes) {
                             obfsPassword = GetMember(obfsOpt, "password");
                         }
                         hysteria2Construct(node, group, ps, server, port, password, host, up, down, alpn,
-                                           obfsParam, obfsPassword, sni, public_key, "", udp, tfo, scv,
+                                           obfsParam, obfsPassword, sni, public_key, fingerprint, "", udp, tfo, scv,
                                            underlying_proxy);
                         break;
                     case "tuic"_hash:

--- a/src/parser/subparser.h
+++ b/src/parser/subparser.h
@@ -31,7 +31,7 @@ void hysteria2Construct(Proxy &node, const std::string &group, const std::string
                         const std::string &port, const std::string &password, const std::string &host,
                         const std::string &up, const std::string &down, const std::string &alpn,
                         const std::string &obfsParam, const std::string &obfsPassword, const std::string &sni,
-                        const std::string &publicKey, const std::string &ports,
+                        const std::string &publicKey, const std::string &fingerprint, const std::string &ports,
                         tribool udp, tribool tfo,
                         tribool scv,const std::string& underlying_proxy="");
 


### PR DESCRIPTION
Parse the pinSHA256 query parameter from hysteria2 URIs into the node fingerprint, emit it as the fingerprint field in Clash output, read it back from Clash YAML and sing-box certificate_public_key_sha256 input, and round-trip it back to pinSHA256 when exporting the URI.