### PR TITLE
fix: default missing VLESS transport type to TCP

### DIFF
--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -1911,6 +1911,8 @@ void explodeStdVless(std::string vless, Proxy &node) {
 
     tls = getUrlArg(addition, "security");
     net = getUrlArg(addition, "type");
+    if (net.empty())
+        net = "tcp";
     flow = getUrlArg(addition, "flow");
     pbk = getUrlArg(addition, "pbk");
     sid = getUrlArg(addition, "sid");


### PR DESCRIPTION
## Problem

`explodeStdVless()` treats a missing `type` query parameter as an unsupported transport. The empty value reaches the default switch branch and returns before `vlessConstruct()`, leaving the proxy as `ProxyType::Unknown`. The node is then silently omitted from the converted subscription.

An omitted transport is a real TCP-default input, not just a malformed edge case:

- The [official Xray share-link proposal](https://github.com/XTLS/Xray-core/discussions/716#5-%E4%B8%BE%E4%BE%8B) includes an example explicitly labeled `VLESS + TCP` whose URI does not contain `type=tcp`.
- Mihomo documents that an unset VLESS [`network`](https://wiki.metacubex.one/en/config/proxies/vless/#network) uses TCP, and subconverter's Clash VLESS parser already applies the same default.

As a result, any provider or exporter that omits the redundant `type=tcp` parameter can lose otherwise usable VLESS nodes during URI subscription parsing, regardless of the selected TLS security or flow.

## Fix

Default a missing VLESS URI `type` to `tcp` before transport-specific parsing. Explicit transport types remain unchanged, and unsupported types are still rejected.

## Testing

- VLESS links without `type` are parsed as TCP.
- Links with an explicit supported transport type retain their existing parsing behavior.
- Unsupported transport types are still rejected.
- Base64 subscription parsing retains the expected VLESS nodes.